### PR TITLE
Update to SpecImageProcessor.java

### DIFF
--- a/galen-core/src/main/java/com/galenframework/speclang2/specs/SpecImageProcessor.java
+++ b/galen-core/src/main/java/com/galenframework/speclang2/specs/SpecImageProcessor.java
@@ -56,7 +56,7 @@ public class SpecImageProcessor implements SpecProcessor {
 
         for (Pair<String, String> parameter : parameters) {
             if ("file".equals(parameter.getKey())) {
-                if (contextPath != null) {
+                if (contextPath != null && System.getProperty('JENKINS_URL') != null) {
                     spec.getImagePaths().add(contextPath + File.separator + parameter.getValue());
                 }
                 else {


### PR DESCRIPTION
Jenkins is seeing issues with an inability for relative paths to be seen from the context.  This is completely different than locally running behavior, and would only be seen on jenkins.

Java 8
galen 2.3.7
chrome 63

